### PR TITLE
[BUG] Add inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scratch/
 
 # integration testing scripts using unpublishable dicoms
 integration_testing.sh
+scripts/
 
 petdeface/pyproject.toml
 petdeface/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ scratch/
 
 # integration testing scripts using unpublishable dicoms
 integration_testing.sh
+
+petdeface/pyproject.toml
+petdeface/Dockerfile
+petdeface/README.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# this makefile allows for some prepacking steps and other quality of life fixes
+# for this repo
+
+# make build activates poetry build after copying over dockerfile and pyproject.toml to petdeface dir
+build:
+	cp Dockerfile petdeface/
+	cp pyproject.toml petdeface/
+	cp README.md petdeface/
+	poetry build
+
+# make publish runs the above make build command, then pushs the most recent build to pypi
+publish: build
+	poetry publish

--- a/petdeface/petdeface.py
+++ b/petdeface/petdeface.py
@@ -273,7 +273,17 @@ def init_single_subject_wf(subject_id: str, bids_dir: str) -> Workflow:
     t1w_wf = Workflow(name="t1w_wf")
     unique_t1w_best_matches = sorted(set(t1w_best_matches))
     for j, t1w_file in enumerate(unique_t1w_best_matches):
-        ses_id = re.search("/ses-(.+?)/", t1w_file).group(1)
+        try:
+            ses_id = re.search("/ses-(.+?)/", t1w_file).group(1)
+        except AttributeError:
+            ses_id = None
+        if not ses_id:
+            out_file = f"sub-{subject_id}.anat"
+            out_facemask = f"sub-{subject_id}.anat.@facemask"
+        else:
+            out_file = f"sub-{subject_id}.ses-{ses_id}.anat"
+            out_facemask = f"sub-{subject_id}.ses-{ses_id}.anat.@facemask"
+
         deface_t1w = Node(
             Mideface(in_file=t1w_file),
             name=f"deface_t1w{j}",
@@ -284,11 +294,8 @@ def init_single_subject_wf(subject_id: str, bids_dir: str) -> Workflow:
                     deface_t1w,
                     datasink,
                     [
-                        ("out_file", f"sub-{subject_id}.ses-{ses_id}.anat"),
-                        (
-                            "out_facemask",
-                            f"sub-{subject_id}.ses-{ses_id}.anat.@facemask",
-                        ),
+                        ("out_file", out_file),
+                        ("out_facemask",out_facemask,),
                     ],
                 ),
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ authors = ["Martin Nørgaard <martin.noergaard@nru.dk>", "Anthony Galassi <28850
 license = "MIT"
 readme = "README.md"
 include = [
-    "petdeface/*",
-    "pyproject.toml",
+    "petdeface/*"
 ]
 
 # please update the bids version to the latest compliant version when making modifications to this code here


### PR DESCRIPTION
Adds inherited anat t1w to workflow. 

Major additional issue is that additional sessions don't get processed, see output below:

```bash
(petdeface-py3.11) [faced_pet_data]$ tree COX-1_analysis_faced_anat_in_first_session_folder/derivatives/petdeface/sub-PS50/
COX-1_analysis_faced_anat_in_first_session_folder/derivatives/petdeface/sub-PS50/
└── ses-baseline
    ├── anat
    │   ├── sub-PS50_ses-baseline_T1w_defaced.nii
    │   └── sub-PS50_ses-baseline_T1w_facemask.nii
    └── pet
        ├── registration.lta
        └── sub-PS50_ses-blocked_pet_defaced.nii.gz

3 directories, 4 files
(petdeface-py3.11) [faced_pet_data]$ tree COX-1_analysis_faced_anat_in_each_session_folder/derivatives/petdeface/sub-PS50/
COX-1_analysis_faced_anat_in_each_session_folder/derivatives/petdeface/sub-PS50/
├── ses-baseline
│   ├── anat
│   │   ├── sub-PS50_ses-baseline_T1w_defaced.nii
│   │   └── sub-PS50_ses-baseline_T1w_facemask.nii
│   └── pet
│       ├── registration.lta
│       └── sub-PS50_ses-blocked_pet_defaced.nii.gz
└── ses-blocked
    └── anat
        ├── sub-PS50_ses-blocked_T1w_defaced.nii
        └── sub-PS50_ses-blocked_T1w_facemask.nii

5 directories, 6 files
(petdeface-py3.11)  [faced_pet_data]$ tree COX-1_analysis_faced_inherit_anat/derivatives/petdeface/sub-PS50/
COX-1_analysis_faced_inherit_anat/derivatives/petdeface/sub-PS50/
├── anat
│   ├── sub-PS50_T1w_defaced.nii
│   └── sub-PS50_T1w_facemask.nii
└── ses-baseline
    └── pet
        ├── registration.lta
        └── sub-PS50_ses-blocked_pet_defaced.nii.gz

3 directories, 4 files
```