### PR TITLE
Improving Visualization of defacing workflow

### DIFF
--- a/petdeface/mideface.py
+++ b/petdeface/mideface.py
@@ -4,6 +4,9 @@ from nipype.interfaces.base import Directory
 from nipype.interfaces.base import File
 from nipype.interfaces.base import TraitedSpec
 from nipype.interfaces.base import traits
+from nipype.interfaces.base import isdefined
+import os
+
 
 
 class MidefaceInputSpec(CommandLineInputSpec):
@@ -145,12 +148,30 @@ class MidefaceInputSpec(CommandLineInputSpec):
 class MidefaceOutputSpec(TraitedSpec):
     out_file = File(desc="Defaced input", exists=True)
     out_facemask = File(desc="Facemask", exists=True)
+    out_before_pic = File(desc="before pic", exists=True)
+    out_after_pic = File(desc="after pic", exists=True)
 
 
 class Mideface(CommandLine):
     _cmd = "mideface"
     input_spec = MidefaceInputSpec
     output_spec = MidefaceOutputSpec
+
+    # def _list_outputs(self):
+    #     outputs = self.output_spec().get()
+    #     pics = self.inputs.pics
+    #     if isdefined(self.inputs.odir) and isdefined(self.inputs.pics) and isdefined(self.inputs.code_name):
+    #         if pics is True:
+    #             out_before_pic = f"{self.inputs.odir}/{self.inputs.code_name}.face-before.png"
+    #             out_after_pic = f"{self.inputs.odir}/{self.inputs.code_name}.face-after.png"
+    #             outputs["out_before_pic"] = os.path.abspath(out_before_pic)
+    #             outputs["out_after_pic"] = os.path.abspath(out_after_pic)
+    #     if isdefined(self.inputs.out_file):
+    #         outputs["out_file"] = os.path.abspath(self.inputs.out_file)
+    #     if isdefined(self.inputs.out_facemask):
+    #         outputs["out_facemask"] = os.path.abspath(self.inputs.out_facemask)
+    #     return outputs
+
 
 
 class ApplyMidefaceInputSpec(CommandLineInputSpec):

--- a/petdeface/mideface.py
+++ b/petdeface/mideface.py
@@ -157,21 +157,23 @@ class Mideface(CommandLine):
     input_spec = MidefaceInputSpec
     output_spec = MidefaceOutputSpec
 
-    # def _list_outputs(self):
-    #     outputs = self.output_spec().get()
-    #     pics = self.inputs.pics
-    #     if isdefined(self.inputs.odir) and isdefined(self.inputs.pics) and isdefined(self.inputs.code_name):
-    #         if pics is True:
-    #             out_before_pic = f"{self.inputs.odir}/{self.inputs.code_name}.face-before.png"
-    #             out_after_pic = f"{self.inputs.odir}/{self.inputs.code_name}.face-after.png"
-    #             outputs["out_before_pic"] = os.path.abspath(out_before_pic)
-    #             outputs["out_after_pic"] = os.path.abspath(out_after_pic)
-    #     if isdefined(self.inputs.out_file):
-    #         outputs["out_file"] = os.path.abspath(self.inputs.out_file)
-    #     if isdefined(self.inputs.out_facemask):
-    #         outputs["out_facemask"] = os.path.abspath(self.inputs.out_facemask)
-    #     return outputs
 
+    def _list_outputs(self):
+        metadata = dict(name_source=lambda t: t is not None)
+        traits = self.inputs.traits(**metadata)
+        if traits:
+            outputs = self.output_spec().trait_get()
+            for name, trait_spec in list(traits.items()):
+                out_name = name
+                if trait_spec.output_name is not None:
+                    out_name = trait_spec.output_name
+                fname = self._filename_from_source(name)
+                if isdefined(fname):
+                    outputs[out_name] = os.path.abspath(fname)
+            if self.inputs.pics is True and self.inputs.odir is not None and self.inputs.code is not None:
+                outputs["out_before_pic"] = os.path.abspath(f"{self.inputs.odir}/{self.inputs.code}.face-before.png")
+                outputs["out_after_pic"] = os.path.abspath(f"{self.inputs.odir}/{self.inputs.code}.face-after.png")
+            return outputs
 
 
 class ApplyMidefaceInputSpec(CommandLineInputSpec):

--- a/petdeface/petdeface.py
+++ b/petdeface/petdeface.py
@@ -256,6 +256,9 @@ def init_single_subject_wf(
         name="sink",
     )
 
+    datasink.inputs.substitutions = [(".face-after", "_desc-faceafter_T1w"),
+                                     ('.face-before', '_desc-facebefore_T1w')]
+
     # deface t1w(s)
     # an MRI might get matched with multiple PET scans, but we need to run
     # deface only once per MRI. This MRI file is the value for each entry in the output of
@@ -288,6 +291,8 @@ def init_single_subject_wf(
                             "out_facemask",
                             f"{anat_string.replace('_', '.')}.anat.@defacemask",
                         ),
+                        ("out_before_pic", f"{anat_string.replace('_', '.')}.anat.@before"),
+                        ("out_after_pic", f"{anat_string.replace('_', '.')}.anat.@after"),
                     ],
                 ),
             ]

--- a/petdeface/petdeface.py
+++ b/petdeface/petdeface.py
@@ -477,7 +477,7 @@ def wrap_up_defacing(
         # we also want to carry over the defacing masks and registration files
         masks_and_reg = list(
             set(
-                layout.get(extension=["mgz", "lta"])
+                layout.get(extension=["mgz", "lta", "png"])
                 + layout.get(suffix="defacemask", extension=["nii.gz", "nii", "mgz"])
             )
         )

--- a/petdeface/petdeface.py
+++ b/petdeface/petdeface.py
@@ -274,7 +274,7 @@ def init_single_subject_wf(
 
         t1w_wf = Workflow(name=workflow_name)
         deface_t1w = Node(
-            Mideface(in_file=pathlib.Path(t1w_file)),
+            Mideface(in_file=pathlib.Path(t1w_file), pics=True, odir=".", code=f"{anat_string}"),
             name=f"deface_t1w_{anat_string}",
         )
         t1w_wf.connect(


### PR DESCRIPTION
This PR adds in the optional before and after pics from Mideface, will be merged once:

- [x] Before and after pics are moved into derivatives folders and bids'ified
- [ ] ~Before and after pics are generated from images defaced with a facemask applied to a non-anatomical image (mideface lacks this capability presently, will need to be done with freeview)~

Known bugs:

- Crashes if not launched from a terminal located on the main display of a Mac, this is a freeview bug, but should have some error handling added in this pipeline...

Closes issue #22 